### PR TITLE
コンポーネントからDBと親の配列データ更新する際、コールバックを使うよう変更

### DIFF
--- a/app/javascript/components/day.vue
+++ b/app/javascript/components/day.vue
@@ -50,10 +50,12 @@ export default defineComponent({
       },
       credentials: 'same-origin'
       })
+      .then(() => {
+        this.$emit('delete', this.date)
+      })
       .catch((error) => {
         console.warn(error)
       })
-      this.$emit('delete', this.date)
     },
     updateCalendar(schedule) {
       const dateState = {year: this.date.year, month: this.date.month, date: this.date.date, schedule: this.markToSchedule[schedule]}
@@ -67,10 +69,12 @@ export default defineComponent({
       body: JSON.stringify(dateState),
       credentials: 'same-origin'
       })
+      .then(() => {
+        this.$emit('update', dateState)
+      })
       .catch((error) => {
         console.warn(error)
       })
-      this.$emit('update', dateState)
     },
   },
   components: {

--- a/app/javascript/components/setting_modal.vue
+++ b/app/javascript/components/setting_modal.vue
@@ -150,11 +150,13 @@ export default defineComponent({
       body: JSON.stringify(setting),
       credentials: 'same-origin'
       })
+      .then(() => {
+        setting['id'] = this.settingId
+        this.$emit('update', setting)
+      })
       .catch((error) => {
         console.warn(error)
-      })
-      setting['id'] = this.settingId
-      this.$emit('update', setting)
+      })  
     },
     reflectSetting(setting) {
       const startDay = new Date(setting.period_start_at)
@@ -188,10 +190,12 @@ export default defineComponent({
       },
       credentials: 'same-origin'
       })
+      .then(() => {
+        this.$emit('delete', settingId)
+      })
       .catch((error) => {
         console.warn(error)
       })
-      this.$emit('delete', settingId)
     },
     createSetting() {
       const startDay = new Date(this.year, (this.selectedStartMonth - 1), this.selectedStartDay)


### PR DESCRIPTION
ref: #50
コンポーネントのDBと親のデータを更新する際の$emitの処理をコールバックを使うよう変更した。
