### PR TITLE
OAuthで一度認証したら再認証しないでもログインできるようにした

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -275,8 +275,6 @@ Devise.setup do |config|
     provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'],
     {
       scope: 'userinfo.email, userinfo.profile, https://www.googleapis.com/auth/calendar',
-      skip_jwt: true,
-      prompt: 'consent'
     }
   end
   OmniAuth.config.allowed_request_methods = %i[get post]


### PR DESCRIPTION
セッションの設定が必要なのかと思っていたが、`config/initializers/devise.rb`で設定した`prompt: 'consent'`のオプションで毎回認証する設定になっていただけだったので、この部分を削除した。