### PR TITLE
年間カレンダー画面を作成した

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -16,11 +16,11 @@
   <select id='specifiy_calendar_year' v-model.number="calendarYear" @change="cancelAutoAdjust">
     <option v-for="year in rangeOfYears" :key="year">{{ year }}</option>
   </select>
-  <select id='specifiy_calendar_month' v-model.number="calendarMonth">
+  <select id='specifiy_calendar_month' v-show="monthly" v-model.number="calendarMonth">
     <option v-for="month in 12" :key="month">{{ month }}</option>
   </select>
   <div v-if="monthly">
-    <div class="calendar-nav__year--month">{{ calendarYear }}年{{ calendarMonth }}月 total:{{ totalWorkingDays[this.calendarMonth] }}</div>
+    <div class="calendar-nav__year--month">{{ calendarYear }}年{{ calendarMonth }}月 合計:{{ totalWorkingDays[this.calendarMonth] }}</div>
     <button v-on:click="this.monthly=false">年間カレンダー</button>
     <table class="calendar">
       <thead class="calendar__header">
@@ -52,8 +52,8 @@
     </table>
   </div>
   <div v-else>
-    <div class="calendar-nav__year">{{ calendarYear }}年 年合計{{ yearyTotal() }}</div>
-    <div v-for="month in 12" :key="month">{{ month }}月 月合計{{ totalWorkingDays[month] }}
+    <div class="calendar-nav__year">{{ calendarYear }}年 合計:{{ yearyTotalWorkingDays() }}</div>
+    <div v-for="month in 12" :key="month">{{ month }}月 合計:{{ totalWorkingDays[month] }}
       <div v-on:click="toMonthlyCalendar(month)"> 
         <table class="calendar">
           <thead class="calendar__header">
@@ -175,7 +175,6 @@ export default defineComponent({
       if (this.calendarMonth === 1) {
         this.calendarMonth = 12
         this.calendarYear--
-        this.fetchCalendarAndSettings()
         this.cancelAutoAdjust()
       } else {
         this.calendarMonth--
@@ -187,7 +186,6 @@ export default defineComponent({
       if (this.calendarMonth === 12) {
         this.calendarMonth = 1
         this.calendarYear++
-        this.fetchCalendarAndSettings()
         this.cancelAutoAdjust()
       } else {
         this.calendarMonth++
@@ -517,7 +515,7 @@ export default defineComponent({
     },
     calendarDates(month) {
       const calendar = []
-      let total = 0
+      let monthlyTotalWorkingDays = 0
       if (this.firstWday(month) > 0) {
         for (let blank = 0; blank < this.firstWday(month); blank++) {
           calendar.push(null)
@@ -537,7 +535,7 @@ export default defineComponent({
             year: this.calendarYear,
             month: month
           })
-          total += this.countTotalWorkingDays(schedule) 
+          monthlyTotalWorkingDays += this.countTotalWorkingDays(schedule) 
         } else {
           calendar.push({
             date: date, 
@@ -547,7 +545,7 @@ export default defineComponent({
           })
         }
       }
-      this.totalWorkingDays[month] = total
+      this.totalWorkingDays[month] = monthlyTotalWorkingDays
       return calendar
     },
     countTotalWorkingDays(schedule) {
@@ -558,12 +556,12 @@ export default defineComponent({
       }
       return 0
     },
-    yearyTotal(){
-      let total = 0
+    yearyTotalWorkingDays(){
+      let totalWorkingDays = 0
       for (let i = 1; i <= 12; i++) {
-        total += this.totalWorkingDays[i]
+        totalWorkingDays += this.totalWorkingDays[i]
       }
-      return total
+      return totalWorkingDays
     },
   },
   components: {

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -19,22 +19,24 @@
   <select id='specifiy_calendar_month' v-model.number="calendarMonth">
     <option v-for="month in 12" :key="month">{{ month }}</option>
   </select>
-  <div class="calendar-nav__year--month">{{ calendarYear }}年{{ calendarMonth }}月 total:{{totalWorkingDays}}</div>
-  <table class="calendar">
-    <thead class="calendar__header">
-      <tr>
-        <th class="calendar__header-day">日</th>
-        <th class="calendar__header-day">月</th>
-        <th class="calendar__header-day">火</th>
-        <th class="calendar__header-day">水</th>
-        <th class="calendar__header-day">木</th>
-        <th class="calendar__header-day">金</th>
-        <th class="calendar__header-day">土</th>
-      </tr>
-    </thead>
-    <tbody v-for="week in calendarWeeks" :key="week.id">
-      <tr class="calendar__week">
-        <td class="calendar__day" 
+  <div v-if="monthly">
+    <div class="calendar-nav__year--month">{{ calendarYear }}年{{ calendarMonth }}月 total:{{totalWorkingDays}}</div>
+    <button v-on:click="this.monthly=false">年間カレンダー</button>
+    <table class="calendar">
+      <thead class="calendar__header">
+        <tr>
+          <th class="calendar__header-day">日</th>
+          <th class="calendar__header-day">月</th>
+          <th class="calendar__header-day">火</th>
+          <th class="calendar__header-day">水</th>
+          <th class="calendar__header-day">木</th>
+          <th class="calendar__header-day">金</th>
+          <th class="calendar__header-day">土</th>
+        </tr>
+      </thead>
+      <tbody v-for="week in calendarWeeks" :key="week.id">
+        <tr class="calendar__week">
+          <td class="calendar__day" 
             v-for='date in week.value'
             :key='date.date'
             :id="'day' + date.date">
@@ -44,10 +46,42 @@
                  v-on:update="updateDay"
                  v-on:delete="deleteDay">
             </Day>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div v-else>
+    <div class="calendar-nav__year">{{ calendarYear }}年 total:{{totalWorkingDays}}</div>
+    <div v-for="month in 12" :key="month">{{ calendarMonth = month }}月
+      <div v-on:click="toMonthlyCalendar(month)"> 
+        <table class="calendar">
+          <thead class="calendar__header">
+            <tr>
+              <th class="calendar__header-day">日</th>
+              <th class="calendar__header-day">月</th>
+              <th class="calendar__header-day">火</th>
+              <th class="calendar__header-day">水</th>
+              <th class="calendar__header-day">木</th>
+              <th class="calendar__header-day">金</th>
+              <th class="calendar__header-day">土</th>
+            </tr>
+          </thead>
+          <tbody v-for="week in calendarWeeks" :key="week.id">
+            <tr class="calendar__week">
+              <td class="calendar__day" 
+                v-for='date in week.value'
+                :key='date.date'
+                :id="'day' + date.date">
+                <div class="calendar__day-label">{{ date.date }}</div>
+                <div>{{ scheduleToMark[date.schedule] }}</div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
   <button v-show="unAutoAdjusted" v-on:click="autoAdjust">適用</button>
   <button v-show="autoAdjusted" v-on:click="determineAutoAdjust">確定</button>
   <button v-show="autoAdjusted" v-on:click="cancelAutoAdjust">キャンセル</button>
@@ -91,6 +125,7 @@ export default defineComponent({
       totalWorkingDays: 0,
       autoAdjusted: false,
       calendarsIndex: [],
+      monthly: false,
     }
   },
   props: {
@@ -168,7 +203,7 @@ export default defineComponent({
         rangeOfYears.push(year)
       }
       return rangeOfYears
-    }
+    },
   },
   mounted() {
     this.fetchCalendarAndSettings()
@@ -515,6 +550,10 @@ export default defineComponent({
           break
         }
       }
+    },
+    toMonthlyCalendar(month) {
+      this.calendarMonth = month
+      this.monthly = true
     },
   },
   components: {


### PR DESCRIPTION
### 概要
一年分のカレンダーを一覧で表示する年間カレンダー画面を作った。
年間カレンダー画面から予定の編集はできないが、自動調整はできる。
月のカレンダーをクリックすると月間カレンダー画面になる。

### 年間カレンダー
<img width="229" alt="スクリーンショット 2023-03-07 0 25 27" src="https://user-images.githubusercontent.com/96340764/223154578-1eec8be5-7991-480f-b7b4-f389276a17c3.png">

### 月間カレンダー
<img width="288" alt="スクリーンショット 2023-03-07 0 26 39" src="https://user-images.githubusercontent.com/96340764/223154625-30c94b12-a149-4343-879e-634f9b75c826.png">
