### PR TITLE
自動調整の機能の挙動を一部変更

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -298,11 +298,6 @@ export default defineComponent({
         if (workingDaysRequired - numberOfWorkingDays > 0) {
           this.errors.push(`${setting.period_start_at} ~ ${setting.period_end_at} までの期間で ${workingDaysRequired - numberOfWorkingDays}日分の勤務日数が足りません`)
         }
-        console.log(workingDaysRequired)
-        console.log(numberOfWorkingDays)
-        console.log(availableDays)
-        console.log(pool)
-        console.log(this.errors)
       }
       this.reflectAdjustedCalendar()
       this.autoAdjusted = true

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -274,12 +274,12 @@ export default defineComponent({
           if ((workingDaysRequired) && (numberOfWorkingDays >= workingDaysRequired) && !(schedule === "off")) {
             continue
           }
-          this.insertSchedule(day, schedule)
           if (schedule === 'full-time') {
             numberOfWorkingDays++
           } else if ((schedule === 'morning') || (schedule === 'afternoon')) {
             numberOfWorkingDays+=0.5
           }
+          this.insertSchedule(day, schedule)
         }
         if (pool.length > 0) {
           for (let poolInDay of pool) {
@@ -295,6 +295,14 @@ export default defineComponent({
             }
           }
         }
+        if (workingDaysRequired - numberOfWorkingDays > 0) {
+          this.errors.push(`${setting.period_start_at} ~ ${setting.period_end_at} までの期間で ${workingDaysRequired - numberOfWorkingDays}日分の勤務日数が足りません`)
+        }
+        console.log(workingDaysRequired)
+        console.log(numberOfWorkingDays)
+        console.log(availableDays)
+        console.log(pool)
+        console.log(this.errors)
       }
       this.reflectAdjustedCalendar()
       this.autoAdjusted = true
@@ -436,8 +444,8 @@ export default defineComponent({
       for (let calendarDay of this.calendarDays) {
         if (calendarDay.date === formatedDay) {
           this.calendarDays.splice(this.calendarDays.indexOf(calendarDay), 1, newDay)
+          break
         }
-        break
       }
       this.calendarDays.push(newDay)
     },

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -126,6 +126,7 @@ export default defineComponent({
       autoAdjusted: false,
       calendarsIndex: [],
       monthly: true,
+      errors: [],
     }
   },
   props: {
@@ -233,6 +234,7 @@ export default defineComponent({
         const startDate = new Date(setting.period_start_at)
         const endDate = new Date(setting.period_end_at)
         let availableDays = new Array()
+        let pool = new Array()
         const workingDaysRequired = setting.total_working_days
         let numberOfWorkingDays = 0
         const schedulesOfWeek = { 
@@ -265,8 +267,11 @@ export default defineComponent({
         for (let availableDay of availableDays) {
           const day = new Date(availableDay)
           const schedule = schedulesOfWeek[day.getDay()]
-          if (schedule === "None") { continue }
-          if ((numberOfWorkingDays >= workingDaysRequired) && !(schedule === "off")) {
+          if (schedule === "None") { 
+            pool.push(availableDay)
+            continue
+          }
+          if ((workingDaysRequired) && (numberOfWorkingDays >= workingDaysRequired) && !(schedule === "off")) {
             continue
           }
           this.insertSchedule(day, schedule)
@@ -274,6 +279,20 @@ export default defineComponent({
             numberOfWorkingDays++
           } else if ((schedule === 'morning') || (schedule === 'afternoon')) {
             numberOfWorkingDays+=0.5
+          }
+        }
+        if (pool.length > 0) {
+          for (let poolInDay of pool) {
+            const day = new Date(poolInDay)
+            if (workingDaysRequired - numberOfWorkingDays === 0.5) {
+              this.insertSchedule(day, "morning")
+              numberOfWorkingDays+=0.5
+            } else if (workingDaysRequired - numberOfWorkingDays >= 1){
+              this.insertSchedule(day, "full-time")
+              numberOfWorkingDays++
+            } else {
+              break
+            }
           }
         }
       }

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -53,7 +53,7 @@
   </div>
   <div v-else>
     <div class="calendar-nav__year">{{ calendarYear }}年 合計:{{ yearyTotalWorkingDays() }}</div>
-    <div v-for="month in 12" :key="month">{{ month }}月 合計:{{ totalWorkingDays[month] }}
+    <div class="calendar-month" v-for="month in 12" :key="month">{{ month }}月 合計:{{ totalWorkingDays[month] }}
       <div v-on:click="toMonthlyCalendar(month)"> 
         <table class="calendar">
           <thead class="calendar__header">
@@ -590,5 +590,8 @@ export default defineComponent({
   width:70%;
   padding: 1em;
   background:#fff;
+}
+.calendar-month{
+  display: inline-block;
 }
 </style>

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -9,7 +9,7 @@
   </select>
   <div v-show="autoAdjusted">
     <div v-if="workingDaysRequired">{{ numberOfWorkingDays }} / {{ workingDaysRequired }}</div>
-    <div v-else>{{workingDaysRequired}}</div>
+    <div v-else>{{ numberOfWorkingDays }}</div>
   </div>
   <div v-if="monthly">
     <div class="calendar-nav__year--month">{{ calendarYear }}年{{ calendarMonth }}月 合計:{{ totalWorkingDays[this.calendarMonth] }}</div>
@@ -437,24 +437,24 @@ export default defineComponent({
       const date = new Date(day.year, day.month - 1, day.date)
       const formatedDay = this.formatUpdatedDay(date)
       const newDay = { date: formatedDay, schedule: day.schedule }
-      const diff = this.updateToCalendarArray(this.calendarDays, formatedDay, newDay)
+      const diff = this.updateToCalendarArray(this.calendarDays, newDay)
       if (this.autoAdjusted) {
         this.numberOfWorkingDays += diff
-        this.updateToCalendarArray(this.adjustedCalendar, formatedDay, newDay)
+        this.updateToCalendarArray(this.adjustedCalendar, newDay)
       } 
     },
     deleteDay(day) {
       const date = new Date(day.year, day.month - 1, day.date)
       const formatedDay = this.formatUpdatedDay(date)
-      const diff = this.deleteFromCalendarArray(this.calendarDays, formatedDay)
+      const diffAmount = this.deleteFromCalendarArray(this.calendarDays, formatedDay)
       if (this.autoAdjusted) {
-        this.numberOfWorkingDays -= diff
+        this.numberOfWorkingDays -= diffAmount
         this.deleteFromCalendarArray(this.adjustedCalendar, formatedDay)
       }
     },
-    updateToCalendarArray(calendarDays, formatedDay, newDay){
+    updateToCalendarArray(calendarDays, newDay){
       for (let calendarDay of calendarDays) {
-        if (calendarDay.date === formatedDay) {
+        if (calendarDay.date === newDay.date) {
           (this.countWorkingDays(calendarDay.schedule) - this.countWorkingDays(newDay.schedule)) 
           calendarDays.splice(calendarDays.indexOf(calendarDay), 1, newDay)
           return (this.countWorkingDays(newDay.schedule) - this.countWorkingDays(calendarDay.schedule)) 

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -380,12 +380,10 @@ export default defineComponent({
     },
     determineAutoAdjust() {
       this.saveAdjustedCalendar()
-      this.lessThanNecessaryMessages = []
       this.autoAdjusted = false
     },
     cancelAutoAdjust() {
       this.adjustedCalendar = [],
-      this.lessThanNecessaryMessages = []
       this.fetchCalendarAndSettings()
       this.autoAdjusted = false
     },

--- a/app/javascript/components/day.vue
+++ b/app/javascript/components/day.vue
@@ -24,6 +24,7 @@ export default defineComponent({
   },
   props: { 
     date: { type: Object, required: true },
+    autoAdjusted: { type: Boolean, required: true },
   },
   methods: {
     token() {
@@ -42,6 +43,10 @@ export default defineComponent({
       this.schedule = this.markToSchedule[scheduleMark]
     },
     deleteDate() {
+      if (this.autoAdjusted) {
+        this.$emit('delete', this.date)
+        return
+      }
       fetch(`days/${this.date.year}/${this.date.month}/${this.date.date}`, {
       method: 'DELETE',
       headers: {
@@ -59,6 +64,10 @@ export default defineComponent({
     },
     updateCalendar(schedule) {
       const dateState = {year: this.date.year, month: this.date.month, date: this.date.date, schedule: this.markToSchedule[schedule]}
+      if (this.autoAdjusted) {
+        this.$emit('update', dateState)
+        return
+      }
       fetch(`days/${this.date.year}/${this.date.month}`, {
       method: 'POST',
       headers: {

--- a/app/javascript/components/setting.vue
+++ b/app/javascript/components/setting.vue
@@ -1,8 +1,10 @@
 <template>
   <p>条件の設定</p>
   <div v-for="setting in slicedSettings" :key="setting.id">
-    <button v-on:click="reflectSetting(setting)">{{ setting.period_start_at }} 〜 {{ setting.period_end_at }}</button>
+    <span>{{ setting.period_start_at }} 〜 {{ setting.period_end_at }}</span>
+    <button v-on:click="editSetting(setting)">編集</button>
     <button v-on:click="deleteSetting(setting.id)">削除</button>
+    <button v-on:click="reflectSetting(setting)">適用</button>
   </div>
   <div v-for="pageNumber in totalPages" :key="pageNumber">
     <button v-on:click="this.currentPage = pageNumber">{{ pageNumber }}</button>
@@ -171,7 +173,7 @@ export default defineComponent({
         console.warn(error)
       })  
     },
-    reflectSetting(setting) {
+    editSetting(setting) {
       const startDay = new Date(setting.period_start_at)
       const endDay = new Date(setting.period_end_at)
       this.totalWorkingDays = setting.total_working_days
@@ -318,7 +320,10 @@ export default defineComponent({
         return true
       }
     },
+    reflectSetting(setting){
+      this.$emit('reflect', setting)
+    }
   },
-  emits: ['close', 'update', 'create', 'delete']
+  emits: ['close', 'update', 'create', 'delete', 'reflect']
 })
 </script>


### PR DESCRIPTION
## 概要
自動調整の際まとめて条件を適用していたのを、一つずつ条件を適用するように変更した。
また、自動調整で条件の適用後、「現在の勤務日数」と「必要勤務日数」を表示し、手動で予定を微調整できるようにした。

### 変更前
条件をモーダルから設定し、カレンダー画面から「適用」で一斉に適用
<img width="449" alt="スクリーンショット 2023-02-25 0 08 37のコピー" src="https://user-images.githubusercontent.com/96340764/224547687-8497b25c-58cf-4f3f-a2dc-69d79f230f36.png">

### 変更後
条件をモーダルで設定し、個別に「適用」するようにした。
条件の横に「編集」ボタン「適用ボタン」も併せて設置。
<img width="503" alt="スクリーンショット 2023-03-11 1 42 45のコピー" src="https://user-images.githubusercontent.com/96340764/224547655-a6abd254-c78f-4027-b1ef-82b1ff685ef8.png">

自動調整で条件の適用後、「現在の勤務日数」と「必要勤務日数」を表示しながら手動調整できるようにした。
<img width="263" alt="スクリーンショット 2023-03-12 2 01 32" src="https://user-images.githubusercontent.com/96340764/224547672-64125970-c58e-41bf-909a-d1f0066e7b01.png">
