### PR TITLE
自動調整の際、期間外の予定を変更できないように修正

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -383,7 +383,7 @@ function autoAdjust(setting) {
   }
   reflectedSetting.value = setting
   autoAdjusted.value = true
-  calendarMonth.value = startDate.getMonth() + 1
+  calendarMonth.value = startDate.getMonth()
 }
 function equalDays(availableDate, date) {
   if (availableDate.getMonth() !== date.getMonth()) { return false }

--- a/spec/system/calendars_spec.rb
+++ b/spec/system/calendars_spec.rb
@@ -101,4 +101,19 @@ RSpec.describe 'Calendars', type: :system do
     click_button '条件の入力'
     expect(page).to_not have_content('2023-01-01 〜 2023-01-31')
   end
+
+  scenario 'user execute autoadjust from setting', js: true do
+    select '2023', from: 'specifiy_calendar_year'
+    click_button '条件の入力'
+    click_button '適用'
+    within '#day20' do
+      expect(find('.calendar__day-body')).to have_content('●')
+    end
+
+    click_button '後'
+    within '#day1' do
+      click_button
+      expect(page).to_not have_content('自動調整の期間外なので変更できません')
+    end
+  end
 end


### PR DESCRIPTION
### 変更点
自動調整の際に期間外の予定を変更できないようにし、変更しようとするとトーストでエラー通知が出るように変更した。
<img width="568" alt="スクリーンショット 2023-03-31 2 20 58" src="https://user-images.githubusercontent.com/96340764/229292084-297f3288-1ee3-4b14-9763-a91cad0fb04a.png">
