### PR TITLE
条件を作るときにカレンダーがない時、新しくカレンダーが作られるようにした

### DIFF
--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -9,7 +9,7 @@ class Api::SettingsController < ApplicationController
   def show; end
 
   def create
-    @calendar = User.find(current_user.id).calendars.find_by(year: params[:calendar_year])
+    @calendar = User.find(current_user.id).calendars.find_or_create_by(year: params[:calendar_year])
     @setting = Setting.new(setting_params.merge(calendar_id: @calendar.id))
     @setting.save!
   end


### PR DESCRIPTION
### 変更点
その年のカレンダーがまだ存在しない場合に条件を新しく作ろうとしてもできなかったので、その場合は新しくカレンダーが作られるようにした。