### PR TITLE
Googleカレンダーへのリクエストで渡す変数を修正

### DIFF
--- a/app/javascript/components/alignment.vue
+++ b/app/javascript/components/alignment.vue
@@ -129,7 +129,7 @@ function fetchGoogleCalendar(calendar, method) {
     'X-CSRF-Token': token(),
     'Content-Type': 'application/json'
   },
-  body: JSON.stringify(workingTimes),
+  body: JSON.stringify(workingTimes.value),
   credentials: 'same-origin'
   })
   .then((response) => {


### PR DESCRIPTION
Googleカレンダーへのリクエストが失敗する原因は、リクエストにアンラップしていない変数を使っていたことだったのでアンラップするように修正した。