### PR TITLE
OAuth::builderの設定をprompt:consentに変更

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -275,6 +275,7 @@ Devise.setup do |config|
     provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'],
     {
       scope: 'userinfo.email, userinfo.profile, https://www.googleapis.com/auth/calendar',
+      prompt: 'consent', access_type: 'offline'
     }
   end
   OmniAuth.config.allowed_request_methods = %i[get post]


### PR DESCRIPTION
### 変更点
本番環境ではOAuthログインの際、`prompt:consent`でないと初回しかrefresh_tokenを取得できない仕様のようなので、`prompt:'consent'`へ設定を変更し、ついでにaccess_type: 'offline'も明示的に設定した。