### PR TITLE
Deviseのページをi-18nに対応した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,10 +85,10 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'letter_opener_web', '~> 2.0'
   gem 'rubocop-fjord', require: false
   gem 'rubocop-rails', require: false
   gem 'slim_lint', require: false
-  gem 'letter_opener_web', '~> 2.0'
 end
 
 gem 'dockerfile-rails', '>= 1.2', group: :development

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :development do
   gem 'rubocop-fjord', require: false
   gem 'rubocop-rails', require: false
   gem 'slim_lint', require: false
+  gem 'letter_opener_web', '~> 2.0'
 end
 
 gem 'dockerfile-rails', '>= 1.2', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,15 @@ GEM
       railties (>= 6.0.0)
     json (2.6.2)
     jwt (2.7.0)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -413,6 +422,7 @@ DEPENDENCIES
   html2slim
   jbuilder
   jsbundling-rails
+  letter_opener_web (~> 2.0)
   meta-tags
   omniauth
   omniauth-google-oauth2

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(_resource)
     calendar_path
   end
- 
+
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale
     I18n.with_locale(locale, &action)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  around_action :switch_locale
+
   def after_sign_in_path_for(_resource)
     calendar_path
+  end
+ 
+  def switch_locale(&action)
+    locale = params[:locale] || I18n.default_locale
+    I18n.with_locale(locale, &action)
+  end
+
+  def default_url_options
+    { locale: I18n.locale }
   end
 end

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -6,9 +6,12 @@ import "../stylesheets/styles.scss"
 
 document.addEventListener('DOMContentLoaded', () => {
   const Calendar = document.querySelector("#app")
-  const userId = Calendar.getAttribute('data-user-id')
+  let userId
+  if (Calendar) {
+    userId = Calendar.getAttribute('data-user-id')
+  }
   const options = {
     timeout: 2000
   }
-  createApp(App, {userId: userId}).use(Toast, options).mount('#app')
+  createApp(App, {userId: userId}).use(Toast, options).mount(Calendar)
 })

--- a/app/views/calendars/index.html.slim
+++ b/app/views/calendars/index.html.slim
@@ -1,7 +1,7 @@
 - set_meta_tags(title:'カレンダー', description:'勤務日自動調整アプリWDDのカレンダー画面です。')
 .container-fluid.col-9
   .d-flex
-    = link_to "Change your password", edit_user_registration_path, class: 'my-2 me-2'
+    = link_to t('devise.passwords.edit.change_your_password'), edit_user_registration_path, class: 'my-2 me-2'
     = button_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'rounded my-2'
   h1.fs-3 カレンダーの作成
   #app(data-user-id="#{current_user.id}")

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
-<h2>Resend confirmation instructions</h2>
+<h2><%= t('.resend_confirmation_instructions') %></h2>
 
-<%= form_with model: @user, url: confirmation_path(resource_name), html: { method: :post } do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
@@ -9,9 +9,8 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit t('.resend_confirmation_instructions') %>
   </div>
 <% end %>
-<%= button_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path, method: :post, data: {turbo: false} %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,19 @@
-<h2><%= t('.resend_confirmation_instructions') %></h2>
+<% set_meta_tags(title:'メールアドレス確認', description:'勤務日自動調整アプリWDDのメールアドレス確認画面です。') %>
+<h2 class="fs-4 my-2"><%= t('.resend_confirmation_instructions') %></h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
+  <div class="field my-2">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
   </div>
 
   <div class="actions">
-    <%= f.submit t('.resend_confirmation_instructions') %>
+    <%= f.submit t('.resend_confirmation_instructions'), class:"btn btn-primary my-2" %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<div class="my-2">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t('.greeting', recipient: @email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('.action'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @email %>!</p>
+<p><%= t('.greeting', recipient: @email) %></p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p><%= t('.message_unconfirmed', email: @resource.unconfirmed_email) %></p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p><%= t('.message', email: @resource.email) %></p>
 <% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p><%= t('.message') %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('.instruction_2') %></p>
+<p><%= t('.instruction_3') %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+<p><%= t('.message') %></p>
 
-<p>Click the link below to unlock your account:</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>
+<p><%= link_to t('.action'), unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -6,7 +6,7 @@
     <%= render "devise/shared/error_messages", resource: resource %>
     <%= f.hidden_field :reset_password_token %>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :password, t('.new_password') %><br />
       <% if @minimum_password_length %>
         <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em><br />
@@ -14,15 +14,17 @@
       <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
     </div>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :password_confirmation, t('.confirm_new_password') %><br />
       <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
     </div>
   
     <div class="actions">
-      <%= f.submit t('.change_my_password') %>
+      <%= f.submit t('.change_my_password'), class:"btn btn-primary my-2" %>
     </div>
   <% end %>
   
-  <%= render "devise/shared/links" %>
+  <div class="my-2">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,26 +1,26 @@
 <% set_meta_tags(title:'パスワードの変更', description:'勤務日自動調整アプリWDDのパスワード変更画面です。') %>
 <div class="container-fluid col-9">
-  <h2 class="fs-4 my-2">Change your password</h2>
-  
-  <%= form_with model: @user, url: password_path(resource_name), html: { method: :put } do |f| %>
+  <h2 class="fs-4 my-2"><%= t('.change_your_password') %></h2>
+
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
     <%= f.hidden_field :reset_password_token %>
   
     <div class="field">
-      <%= f.label :password, "New password" %><br />
+      <%= f.label :password, t('.new_password') %><br />
       <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+        <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em><br />
       <% end %>
       <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
     </div>
   
     <div class="field">
-      <%= f.label :password_confirmation, "Confirm new password" %><br />
+      <%= f.label :password_confirmation, t('.confirm_new_password') %><br />
       <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
     </div>
   
     <div class="actions">
-      <%= f.submit "Change my password" %>
+      <%= f.submit t('.change_my_password') %>
     </div>
   <% end %>
   

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,8 +1,8 @@
 <% set_meta_tags(title:'パスワード再設定', description:'勤務日自動調整アプリWDDのパスワード再設定画面です。') %>
 <div class="container-fluid col-9">
-  <h2 class="fs-4 my-2">Forgot your password?</h2>
-  
-  <%= form_with model: @user, url: password_path(resource_name), html: { method: :post } do |f| %>
+  <h2 class="fs-4 my-2"><%= t('.forgot_your_password') %></h2>
+
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
   
     <div class="field">
@@ -11,7 +11,7 @@
     </div>
   
     <div class="actions">
-      <%= f.submit "Send me reset password instructions" %>
+      <%= f.submit t('.send_me_reset_password_instructions') %>
     </div>
   <% end %>
   

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,15 +5,17 @@
   <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :email %><br />
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
   
     <div class="actions">
-      <%= f.submit t('.send_me_reset_password_instructions') %>
+      <%= f.submit t('.send_me_reset_password_instructions'), class:"btn btn-primary my-2" %>
     </div>
   <% end %>
-  
-  <%= render "devise/shared/links" %>
+
+  <div class="my-2">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :email %><br />
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
@@ -14,7 +14,7 @@
       <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
     <% end %>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
       <%= f.password_field :password, autocomplete: "new-password" %>
       <% if @minimum_password_length %>
@@ -23,24 +23,26 @@
       <% end %>
     </div>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :password_confirmation %><br />
       <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
     </div>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
       <%= f.password_field :current_password, autocomplete: "current-password" %>
     </div>
   
     <div class="actions">
-      <%= f.submit t('.update') %>
+      <%= f.submit t('.update'), class:"btn btn-primary my-2" %>
     </div>
   <% end %>
   
-  <h3><%= t('.cancel_my_account') %></h3>
+  <h3 class="fs-5 my-2"><%= t('.cancel_my_account') %></h3>
   
-  <p><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %></p>
+  <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class:"rounded mb-2" %>
   
-  <%= link_to t('devise.shared.links.back'), :back %>
+  <div class="my-2">
+    <%= link_to t('devise.shared.links.back'), :back %>
+  </div>
   

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,9 +1,8 @@
 <% set_meta_tags(title:'ユーザー情報の編集', description:'勤務日自動調整アプリWDDのユーザー編集画面です。') %>
 <div class="container-fluid col-9">
+  <h2 class="fs-4 my-2"><%= t('.title', resource: resource.model_name.human) %></h2>
 
-  <h2 class="fs-4 my-2">Edit <%= resource_name.to_s.humanize %></h2>
-  
-  <%= form_with model: @user, url: registration_path(resource_name), html: { method: :put } do |f| %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
   
     <div class="field">
@@ -12,15 +11,15 @@
     </div>
   
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
     <% end %>
   
     <div class="field">
-      <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+      <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
       <%= f.password_field :password, autocomplete: "new-password" %>
       <% if @minimum_password_length %>
         <br />
-        <em><%= @minimum_password_length %> characters minimum</em>
+        <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
       <% end %>
     </div>
   
@@ -30,16 +29,18 @@
     </div>
   
     <div class="field">
-      <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+      <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
       <%= f.password_field :current_password, autocomplete: "current-password" %>
     </div>
   
     <div class="actions">
-      <%= f.submit "Update" %>
+      <%= f.submit t('.update') %>
     </div>
   <% end %>
   
-  <h3>Cancel my account</h3>
-  <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-  <%= link_to "Back", :back %>
-</div>
+  <h3><%= t('.cancel_my_account') %></h3>
+  
+  <p><%= t('.unhappy') %> <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %></p>
+  
+  <%= link_to t('devise.shared.links.back'), :back %>
+  

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,8 +1,8 @@
 <% set_meta_tags(title:'サインアップ', description:'勤務日自動調整アプリWDDのユーザー登録画面です。') %>
 <div class="container-fluid col-9">
-  <h2 class="fs-4 my-2">Sign up</h2>
-  
-  <%= form_with model: @user, url: registration_path(resource_name) do |f| %>
+  <h2 class="fs-4 my-2"><%= t('.sign_up') %></h2>
+
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
   
     <div class="field">
@@ -13,7 +13,7 @@
     <div class="field">
       <%= f.label :password %>
       <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em>
+      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
       <% end %><br />
       <%= f.password_field :password, autocomplete: "new-password" %>
     </div>
@@ -24,9 +24,10 @@
     </div>
   
     <div class="actions">
-      <%= f.submit "Sign up" %>
+      <%= f.submit t('.sign_up') %>
     </div>
   <% end %>
   
   <%= render "devise/shared/links" %>
 </div>
+  

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,12 +5,12 @@
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :email %><br />
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :password %>
       <% if @minimum_password_length %>
       <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
@@ -18,16 +18,17 @@
       <%= f.password_field :password, autocomplete: "new-password" %>
     </div>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :password_confirmation %><br />
       <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
     </div>
   
     <div class="actions">
-      <%= f.submit t('.sign_up') %>
+      <%= f.submit t('.sign_up'), class:"btn btn-primary my-2" %>
     </div>
   <% end %>
-  
-  <%= render "devise/shared/links" %>
+
+  <div class="my-2">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>
-  

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,27 +3,29 @@
   <h2 class="fs-4 my-2"><%= t('.sign_in') %></h2>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :email %><br />
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
   
-    <div class="field">
+    <div class="field my-2">
       <%= f.label :password %><br />
       <%= f.password_field :password, autocomplete: "current-password" %>
     </div>
   
     <% if devise_mapping.rememberable? %>
-      <div class="field">
+      <div class="field my-2">
         <%= f.check_box :remember_me %>
         <%= f.label :remember_me %>
       </div>
     <% end %>
   
     <div class="actions">
-      <%= f.submit t('.sign_in') %>
+      <%= f.submit t('.sign_in'), class:"btn btn-primary my-2" %>
     </div>
   <% end %>
-  
-  <%= render "devise/shared/links" %>
+
+  <div class="my-2">
+    <%= render "devise/shared/links" %>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,27 +1,27 @@
 <% set_meta_tags(title:'ログイン', description:'勤務日自動調整アプリWDDのログイン画面です。') %>
 <div class="container-fluid col-9">
-  <h2 class="fs-4 my-2">Log in</h2>
-  
-  <%= form_with model: @user, url: session_path(resource_name) do |f| %>
-    <div class="field my-2">
-      <%= f.label :email, class: "form-label" %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email"%>
+  <h2 class="fs-4 my-2"><%= t('.sign_in') %></h2>
+
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
   
-    <div class="field my-2">
-      <%= f.label :password, class: "form-label" %><br />
+    <div class="field">
+      <%= f.label :password %><br />
       <%= f.password_field :password, autocomplete: "current-password" %>
     </div>
   
     <% if devise_mapping.rememberable? %>
-      <div class="field my-2">
+      <div class="field">
         <%= f.check_box :remember_me %>
         <%= f.label :remember_me %>
       </div>
     <% end %>
   
-    <div class="actions my-2">
-      <%= f.submit "Log in" %>
+    <div class="actions">
+      <%= f.submit t('.sign_in') %>
     </div>
   <% end %>
   

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,21 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,23 +1,33 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+  <div class="my-2">
+    <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+  </div>
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+  <div class="my-2">
+    <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+  </div>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+  <div class="my-2">
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+  </div>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  <div class="my-2">
+    <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  </div>
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+  <div class="my-2">
+    <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+  </div>
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
-  <%= button_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path, method: :post, data: {turbo: false} %>
+  <%= button_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path, method: :post, data: {turbo: false}, class:"my-2" %>
 <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Resend unlock instructions</h2>
+<h2><%= t('.resend_unlock_instructions') %></h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
+    <%= f.submit t('.resend_unlock_instructions') %>
   </div>
 <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,8 @@ module WorkingDayDeployer
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb, yml}')]
+    config.i18n.available_locales = [:en, :ja]
     config.i18n.default_locale = :ja
     config.generators do |g|
       g.test_framework :rspec,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,9 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,65 +1,149 @@
 # Additional translations at https://github.com/heartcombo/devise/wiki/I18n
 
 en:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: Confirmation sent at
+        confirmation_token: Confirmation token
+        confirmed_at: Confirmed at
+        created_at: Created at
+        current_password: Current password
+        current_sign_in_at: Current sign in at
+        current_sign_in_ip: Current sign in IP
+        email: Email
+        encrypted_password: Encrypted password
+        failed_attempts: Failed attempts
+        last_sign_in_at: Last sign in at
+        last_sign_in_ip: Last sign in IP
+        locked_at: Locked at
+        password: Password
+        password_confirmation: Password confirmation
+        remember_created_at: Remember created at
+        remember_me: Remember me
+        reset_password_sent_at: Reset password sent at
+        reset_password_token: Reset password token
+        sign_in_count: Sign in count
+        unconfirmed_email: Unconfirmed email
+        unlock_token: Unlock token
+        updated_at: Updated at
+    models:
+      user:
+        one: User
+        other: Users
   devise:
     confirmations:
-      confirmed: "Your email address has been successfully confirmed."
-      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      confirmed: Your email address has been successfully confirmed.
+      new:
+        resend_confirmation_instructions: Resend confirmation instructions
+      send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:
-      already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
-      invalid: "Invalid %{authentication_keys} or password."
-      locked: "Your account is locked."
-      last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
-      timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
-      unconfirmed: "You have to confirm your email address before continuing."
+      already_authenticated: You are already signed in.
+      inactive: Your account is not activated yet.
+      invalid: Invalid %{authentication_keys} or password.
+      last_attempt: You have one more attempt before your account is locked.
+      locked: Your account is locked.
+      not_found_in_database: Invalid %{authentication_keys} or password.
+      timeout: Your session expired. Please sign in again to continue.
+      unauthenticated: You need to sign in or sign up before continuing.
+      unconfirmed: You have to confirm your email address before continuing.
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
-      reset_password_instructions:
-        subject: "Reset password instructions"
-      unlock_instructions:
-        subject: "Unlock instructions"
+        action: Confirm my account
+        greeting: Welcome %{recipient}!
+        instruction: 'You can confirm your account email through the link below:'
+        subject: Confirmation instructions
       email_changed:
-        subject: "Email Changed"
+        greeting: Hello %{recipient}!
+        message: We're contacting you to notify you that your email has been changed to %{email}.
+        message_unconfirmed: We're contacting you to notify you that your email is being changed to %{email}.
+        subject: Email Changed
       password_change:
-        subject: "Password Changed"
+        greeting: Hello %{recipient}!
+        message: We're contacting you to notify you that your password has been changed.
+        subject: Password Changed
+      reset_password_instructions:
+        action: Change my password
+        greeting: Hello %{recipient}!
+        instruction: Someone has requested a link to change your password. You can do this through the link below.
+        instruction_2: If you didn't request this, please ignore this email.
+        instruction_3: Your password won't change until you access the link above and create a new one.
+        subject: Reset password instructions
+      unlock_instructions:
+        action: Unlock my account
+        greeting: Hello %{recipient}!
+        instruction: 'Click the link below to unlock your account:'
+        message: Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+        subject: Unlock instructions
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
+      failure: Could not authenticate you from %{kind} because "%{reason}".
+      success: Successfully authenticated from %{kind} account.
     passwords:
-      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
+      edit:
+        change_my_password: Change my password
+        change_your_password: Change your password
+        confirm_new_password: Confirm new password
+        new_password: New password
+      new:
+        forgot_your_password: Forgot your password?
+        send_me_reset_password_instructions: Send me reset password instructions
+      no_token: You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.
+      send_instructions: You will receive an email with instructions on how to reset your password in a few minutes.
+      send_paranoid_instructions: If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.
+      updated: Your password has been changed successfully. You are now signed in.
+      updated_not_active: Your password has been changed successfully.
     registrations:
-      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
-      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
-      updated: "Your account has been updated successfully."
-      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+      destroyed: Bye! Your account has been successfully cancelled. We hope to see you again soon.
+      edit:
+        are_you_sure: Are you sure?
+        cancel_my_account: Cancel my account
+        currently_waiting_confirmation_for_email: 'Currently waiting confirmation for: %{email}'
+        leave_blank_if_you_don_t_want_to_change_it: leave blank if you don't want to change it
+        title: Edit %{resource}
+        unhappy: Unhappy?
+        update: Update
+        we_need_your_current_password_to_confirm_your_changes: we need your current password to confirm your changes
+      new:
+        sign_up: Sign up
+      signed_up: Welcome! You have signed up successfully.
+      signed_up_but_inactive: You have signed up successfully. However, we could not sign you in because your account is not yet activated.
+      signed_up_but_locked: You have signed up successfully. However, we could not sign you in because your account is locked.
+      signed_up_but_unconfirmed: A message with a confirmation link has been sent to your email address. Please follow the link to activate your account.
+      update_needs_confirmation: You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address.
+      updated: Your account has been updated successfully.
+      updated_but_not_signed_in: Your account has been updated successfully, but since your password was changed, you need to sign in again.
     sessions:
-      signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."
+      already_signed_out: Signed out successfully.
+      new:
+        sign_in: Log in
+      signed_in: Signed in successfully.
+      signed_out: Signed out successfully.
+    shared:
+      links:
+        back: Back
+        didn_t_receive_confirmation_instructions: Didn't receive confirmation instructions?
+        didn_t_receive_unlock_instructions: Didn't receive unlock instructions?
+        forgot_your_password: Forgot your password?
+        sign_in: Log in
+        sign_in_with_provider: Sign in with %{provider}
+        sign_up: Sign up
+      minimum_password_length:
+        one: "(%{count} character minimum)"
+        other: "(%{count} characters minimum)"
     unlocks:
-      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
-      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+      new:
+        resend_unlock_instructions: Resend unlock instructions
+      send_instructions: You will receive an email with instructions for how to unlock your account in a few minutes.
+      send_paranoid_instructions: If your account exists, you will receive an email with instructions for how to unlock it in a few minutes.
+      unlocked: Your account has been unlocked successfully. Please sign in to continue.
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try signing in"
-      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
-      expired: "has expired, please request a new one"
-      not_found: "not found"
-      not_locked: "was not locked"
+      already_confirmed: was already confirmed, please try signing in
+      confirmation_period_expired: needs to be confirmed within %{period}, please request a new one
+      expired: has expired, please request a new one
+      not_found: not found
+      not_locked: was not locked
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
+        one: '1 error prohibited this %{resource} from being saved:'
         other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   draw :api
   get 'privacy_policy', to: 'home#privacy_policy', as: 'privacy_policy'
   get 'tos', to: 'home#tos', as: 'tos'
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
### 変更点
- Deviseの各Viewとメールの文面をi-18nでjp/enに対応した。
- Deviseの各ページにデザインを入れた。
- メールの文面確認のためletter_openerのGemを入れた。
- ログインしていない時に出る`element.getAttribute`がnullだという警告が出ないよう修正した。

### 備考
- その他の部分はi18n未対応
- 表記は`?locale=en`クエリで切り替えられるのみで、切り替えボタンなどは作っていない。