### PR TITLE
連携機能モーダルのボタンを未認証時に押せないようにした

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -109,12 +109,12 @@
     <div id=overlay  v-show="showContent">
       <div id=content>
         <Setting v-bind:year="calendarYear"
-               v-bind:settings="settings"
-               v-on:close="closeModal"
-               v-on:update="updateSetting"
-               v-on:create="createSetting"
-               v-on:delete="deleteSetting"
-               v-on:reflect="adjustAndReflect">
+                 v-bind:settings="settings"
+                 v-on:close="closeModal"
+                 v-on:update="updateSetting"
+                 v-on:create="createSetting"
+                 v-on:delete="deleteSetting"
+                 v-on:reflect="adjustAndReflect">
         </Setting>
       </div>
     </div>

--- a/app/javascript/components/alignment.vue
+++ b/app/javascript/components/alignment.vue
@@ -20,7 +20,7 @@
     <div class="exist-calendars-area my-2">
       <div v-if="haveNoCalendars">カレンダーがまだありません</div>
       <div v-else>
-        <div class="my-1" v-for="calendar in slicedCalendars" :key="calendar.year">
+        <div class="my-2" v-for="calendar in slicedCalendars" :key="calendar.year">
           <span class="calendar_year__body">{{ calendar.year }}年</span>
           <button class="btn btn-dark ms-1"
                   v-bind:disabled="calendar.google_calendar_id || isFetching || notAuthenticatedGoogle"
@@ -37,9 +37,9 @@
         </div>
       </div>
     </div>
-    <div class="pagenation">
-      <span v-for="(pageNumber, index) in displayPageNumbers" :key="index">
-        <span class="page-number m-1 fs-5"
+    <div class="pagenation my-2">
+      <span class="page-number m-1 fs-5" v-for="(pageNumber, index) in displayPageNumbers" :key="index">
+        <span 
               v-bind:class="{'current-page':currentPage === pageNumber}"
               v-on:click="updatePageNumber(pageNumber, index)">
           {{ pageNumber }}
@@ -332,11 +332,8 @@ function timesValidation() {
   padding: 1em;
   background:#fff;
 }
-.google-calendar{
-  height: 300px;
-}
 .exist-calendars-area{
-  height: 180px;
+  height: 220px;
 }
 .page-number{
   text-decoration: underline;

--- a/app/javascript/components/alignment.vue
+++ b/app/javascript/components/alignment.vue
@@ -12,7 +12,10 @@
   </div>
   <div class="google-calendar my-2">
     <h3 class="fs-5 my-2">Googleカレンダー</h3>
-    <button v-if="notAuthenticatedGoogle" v-on:click="redirectOAuth">Sign in with Google</button>
+    <div v-if="notAuthenticatedGoogle">
+      <p>Googleカレンダーと連携するにはGoogle認証が必要です</p>
+      <button v-on:click="redirectOAuth">Sign in with Google</button>
+    </div>
     <p v-else>認証済</p>
     <div class="exist-calendars-area my-2">
       <div v-if="haveNoCalendars">カレンダーがまだありません</div>
@@ -20,15 +23,15 @@
         <div class="my-1" v-for="calendar in slicedCalendars" :key="calendar.year">
           <span class="calendar_year__body">{{ calendar.year }}年</span>
           <button class="btn btn-dark ms-1"
-                  v-bind:disabled="calendar.google_calendar_id || isFetching"
+                  v-bind:disabled="calendar.google_calendar_id || isFetching || notAuthenticatedGoogle"
                   v-on:click="fetchGoogleCalendar(calendar, requestMethods['create'])">追加
           </button>
           <button class="btn btn-dark ms-1"
-                  v-bind:disabled="notExistsGoogleId(calendar.google_calendar_id) || isFetching"
+                  v-bind:disabled="notExistsGoogleId(calendar.google_calendar_id) || isFetching || notAuthenticatedGoogle"
                   v-on:click="fetchGoogleCalendar(calendar, requestMethods['update'])">更新
           </button>
           <button class="btn btn-dark ms-1"
-                  v-bind:disabled="notExistsGoogleId(calendar.google_calendar_id) || isFetching"
+                  v-bind:disabled="notExistsGoogleId(calendar.google_calendar_id) || isFetching || notAuthenticatedGoogle"
                   v-on:click="confirmDialog(calendar)">削除
           </button>
         </div>

--- a/app/javascript/components/alignment.vue
+++ b/app/javascript/components/alignment.vue
@@ -12,16 +12,18 @@
   </div>
   <div class="google-calendar my-2">
     <h3 class="fs-5 my-2">Googleカレンダー</h3>
-    <div v-if="notAuthenticatedGoogle">
+    <div class="my-2" v-if="notAuthenticatedGoogle">
       <p>Googleカレンダーと連携するにはGoogle認証が必要です</p>
       <button v-on:click="redirectOAuth">Sign in with Google</button>
     </div>
-    <p v-else>認証済</p>
+    <div class="my-2" v-else>
+      <p >認証済</p>
+    </div>
     <div class="exist-calendars-area my-2">
       <div v-if="haveNoCalendars">カレンダーがまだありません</div>
       <div v-else>
-        <div class="my-2" v-for="calendar in slicedCalendars" :key="calendar.year">
-          <span class="calendar_year__body">{{ calendar.year }}年</span>
+        <div class="my-2" v-for="(calendar, index) in slicedCalendars" :key="index">
+          <span class="calendar_year__body me-3">{{ calendar.year }}年</span>
           <button class="btn btn-dark ms-1"
                   v-bind:disabled="calendar.google_calendar_id || isFetching || notAuthenticatedGoogle"
                   v-on:click="fetchGoogleCalendar(calendar, requestMethods['create'])">追加

--- a/app/javascript/components/setting.vue
+++ b/app/javascript/components/setting.vue
@@ -1,6 +1,6 @@
 <template>
   <h2 class="fs-4 my-2">条件一覧</h2>
-  <div id=overlay  v-show="confirmedSetting">
+  <div id=overlay v-show="confirmedSetting">
     <div id=confirm>
       <Confirm v-on:delete="deleteSetting(confirmedSetting.id)"
                v-on:cancel="cancelConfirm">

--- a/app/javascript/components/setting.vue
+++ b/app/javascript/components/setting.vue
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div class="setting">
-    <div class="settings-area ">
+    <div class="settings-area">
       <span class="have-no-settings" v-show="props.settings.length < 1">まだ条件がありません</span>
       <div v-for="setting in slicedSettings" :key="setting.id">
         <span class="setting-periods m-2 fs-6 rounded" v-bind:class="{'selected': settingId === setting.id}">
@@ -465,6 +465,9 @@ function totalDaysValidation(startDay, endDay) {
 .setting-periods{
   display: inline-block;
   width: 220px;
+}
+.settings-area{
+  height: 220px;
 }
 .page-number{
   text-decoration: underline;


### PR DESCRIPTION
### 変更点
- Google認証ができていないときにメッセージを表示し、ボタンを押せないようにした。
- エリアの高さを固定して、一覧に表示される数でレイアウトが変わらないようにした。
<img width="340" alt="スクリーンショット 2023-05-10 2 19 16" src="https://github.com/tomonariha/working-day-deployer/assets/96340764/0e1ecaa0-346a-47d5-a1a6-cc1d20b2658c">
