### PR TITLE
自動調整の際、指定した日数と現在の日数がずれている場合に確認ダイアログを出すようにした

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -22,10 +22,19 @@
       <p class="current-working-days rounded"> (現在の日数){{ numberOfWorkingDays }}</p>
     </div>
   </div>
-  <div id=overlay v-show="showConfirm">
+  <div id=overlay v-show="showJustNotConfirm">
     <div id=confirm>
-      <Confirm v-on:delete='deleteCalendar'
-               v-on:cancel='cancelConfirm'>
+      <Confirm v-bind:message="'日数に過不足がありますが、確定してよろしいですか？'"
+               v-on:execution="determineAutoAdjust"
+               v-on:cancel="cancelJustNotConfirm">
+      </Confirm>
+    </div>
+  </div>
+  <div id=overlay v-show="showDeleteConfirm">
+    <div id=confirm>
+      <Confirm v-bind:message="'削除します。よろしいですか？'"
+               v-on:execution='deleteCalendar'
+               v-on:cancel='cancelDeleteConfirm'>
       </Confirm>
     </div>
   </div>
@@ -118,7 +127,12 @@
         </Setting>
       </div>
     </div>
-  <button type="button" class="btn btn-success my-2 me-2" v-show="autoAdjusted" v-on:click="determineAutoAdjust">確定</button>
+  <span v-if="numberOfWorkingDays !== workingDaysRequired">
+      <button type="button" class="btn btn-success my-2 me-2" v-show="autoAdjusted" v-on:click="confirmJustNot">確定</button>
+  </span>
+  <span v-else>
+    <button type="button" class="btn btn-success my-2 me-2" v-show="autoAdjusted" v-on:click="determineAutoAdjust">確定</button>
+  </span>
   <button type="button" class="btn btn-secondary my-2 me-2" v-show="autoAdjusted" v-on:click="cancelAutoAdjust">キャンセル</button>
   <button type="button" class="btn btn-primary my-2" v-show="unAutoAdjusted" v-on:click="openAlignmentModal">連携</button>
     <div id=overlay  v-show="showAlignmentContent">
@@ -466,6 +480,7 @@ function extractCalendarDaysWithinPeriod(startDate, endDate) {
   return calendar
 }
 function determineAutoAdjust() {
+  cancelJustNotConfirm()
   saveAdjustedCalendar()
   toast("適用しました")
   autoAdjusted.value = false
@@ -611,15 +626,15 @@ function deleteFromCalendarArray(calendarDays, formatedDay) {
   }
 }
 // 確認ダイアログ
-const showConfirm = ref(false)
+const showDeleteConfirm = ref(false)
 function confirmDeleteCalendar(){
   fetchCalendar().then(function() {
     fetchSettings();
   })
-  showConfirm.value = true
+  showDeleteConfirm.value = true
 }
-function cancelConfirm() {
-  showConfirm.value = false
+function cancelDeleteConfirm() {
+  showDeleteConfirm.value = false
 }
 function deleteCalendar() {
   fetch(`api/calendars/${calendarYear.value}`, {
@@ -639,7 +654,7 @@ function deleteCalendar() {
   .catch((error) => {
     console.warn(error)
   })
-  cancelConfirm()
+  cancelDeleteConfirm()
 }
 function deleteFromCalendarsIndex() {
   for (let calendar of calendarsIndex.value) {
@@ -648,6 +663,13 @@ function deleteFromCalendarsIndex() {
       break
     }
   }
+}
+const showJustNotConfirm = ref(false)
+function confirmJustNot() {
+  showJustNotConfirm.value = true
+}
+function cancelJustNotConfirm() {
+  showJustNotConfirm.value = false
 }
 //外部アプリ連携関連
 const showAlignmentContent = ref(false)

--- a/app/javascript/components/alignment.vue
+++ b/app/javascript/components/alignment.vue
@@ -2,7 +2,8 @@
   <h2 class="fs-4 my-2">連携機能</h2>
   <div id=overlay v-show="confirmedCalendar">
     <div id=confirm>
-      <Confirm v-on:delete="fetchGoogleCalendar(confirmedCalendar, requestMethods['delete'])"
+      <Confirm v-bind:message="'削除します。よろしいですか？'"
+               v-on:execution="fetchGoogleCalendar(confirmedCalendar, requestMethods['delete'])"
                v-on:cancel="cancelConfirm">
       </Confirm>
     </div>

--- a/app/javascript/components/confirm.vue
+++ b/app/javascript/components/confirm.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="confirm">
-    <p>削除します。よろしいですか？</p>
-    <button class="rounded m-1" v-on:click="emit('delete')">はい</button>
+    <p>{{ props.message }}</p>
+    <button class="rounded m-1" v-on:click="emit('execution')">はい</button>
     <button class="rounded m-1" v-on:click="emit('cancel')">いいえ</button>
   </div>
 </template>
 
 <script setup>
-const emit = defineEmits(['cancel', 'delete'])
+const props = defineProps({ 
+  message: String
+})
+const emit = defineEmits(['execution', 'cancel'])
 </script>

--- a/app/javascript/components/setting.vue
+++ b/app/javascript/components/setting.vue
@@ -2,7 +2,8 @@
   <h2 class="fs-4 my-2">条件一覧</h2>
   <div id=overlay v-show="confirmedSetting">
     <div id=confirm>
-      <Confirm v-on:delete="deleteSetting(confirmedSetting.id)"
+      <Confirm v-bind:message="'削除します。よろしいですか？'"
+               v-on:execution="deleteSetting(confirmedSetting.id)"
                v-on:cancel="cancelConfirm">
       </Confirm>
     </div>

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -14,7 +14,8 @@ class Day < ApplicationRecord
     unless (schedule == 'full-time') ||
            (schedule == 'morning') ||
            (schedule == 'afternoon') ||
-           (schedule == 'off')
+           (schedule == 'off') ||
+           (schedule == 'paidleave')
       errors.add(:schedule, '無効な文字列です')
     end
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -34,9 +34,8 @@ class Setting < ApplicationRecord
   def total_working_days_should_be_between_0_and_days_in_period
     return unless total_working_days
 
-    number_of_days_in_period = (period_start_at...period_end_at).count
+    number_of_days_in_period = (period_start_at..period_end_at).count
     return unless (total_working_days > number_of_days_in_period) || total_working_days.negative?
-
     errors.add(:total_working_days, '勤務日数は０以上期間内の日数以下にしてください')
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -35,7 +35,9 @@ class Setting < ApplicationRecord
     return unless total_working_days
 
     number_of_days_in_period = (period_start_at..period_end_at).count
+
     return unless (total_working_days > number_of_days_in_period) || total_working_days.negative?
+
     errors.add(:total_working_days, '勤務日数は０以上期間内の日数以下にしてください')
   end
 end


### PR DESCRIPTION
### 変更点
自動調整をして確定ボタンを押す際、現在の日数と必要日数がずれていた場合に確認ダイアログを出すようにした。
<img width="555" alt="スクリーンショット 2023-05-20 3 12 54" src="https://github.com/tomonariha/working-day-deployer/assets/96340764/cdeb13e3-8458-4c4f-91c3-9a5eb21511cf">
