### PR TITLE
時刻の設定で表示される数字を２桁にした

### DIFF
--- a/app/javascript/components/time.vue
+++ b/app/javascript/components/time.vue
@@ -2,26 +2,26 @@
   <div class="my-1">
     <span>{{ schedules[props.dayOfSchedule] }}</span>
     <select v-model.number="workingTimes[`${props.dayOfSchedule}StartHour`]" >
-      <option v-for="hour in 24" :key="hour">
-        {{ hour -1 }}
+      <option v-for="hour in 24" :key="hour" :value="hour-1" :selected="hour-1 === workingTimes[`${props.dayOfSchedule}StartHour`]">
+        {{ formatTimeNumber(hour-1) }}
       </option>
     </select>
     <span>時</span>
     <select v-model.number="workingTimes[`${props.dayOfSchedule}StartMinit`]">
-      <option v-for="minit in minits" :key="minit">
-        {{ minit }}
+      <option v-for="minit in minits" :key="minit" :value="minit" :selected="minit === workingTimes[`${props.dayOfSchedule}StartMinit`]">
+        {{ formatTimeNumber(minit) }}
       </option>
     </select>
     <span>分〜</span>
     <select v-model.number="workingTimes[`${props.dayOfSchedule}EndHour`]">
-      <option v-for="hour in 24" :key="hour">
-        {{ hour -1 }}
+      <option v-for="hour in 24" :key="hour-1" :value="hour-1" :selected="hour-1 === workingTimes[`${props.dayOfSchedule}EndHour`]">
+        {{ formatTimeNumber(hour-1) }}
       </option>
     </select>
     <span>時</span>
     <select v-model.number="workingTimes[`${props.dayOfSchedule}EndMinit`]">
-      <option v-for="minit in minits" :key="minit">
-        {{ minit }}
+      <option v-for="minit in minits" :key="minit" :value="minit" :selected="minit === workingTimes[`${props.dayOfSchedule}EndMinit`]">
+        {{ formatTimeNumber(minit) }}
       </option>
     </select>
     <span>分</span>
@@ -29,11 +29,14 @@
 </template>
 
 <script setup>
-import { ref, onMounted, inject} from 'vue'
+import { ref, onMounted, inject } from 'vue'
 const props = defineProps({
   dayOfSchedule: String
 })
 const schedules = { 'morning':'午前: ', 'afterNoon':'午後: ', 'fullTime': '全日: ' }
 const workingTimes = inject('workingTimes')
 const minits = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]
+function formatTimeNumber(i) {
+  return i.toString().padStart(2, '0')
+}
 </script>


### PR DESCRIPTION
時刻の設定のセレクトボックスで、数字が一桁の場合そのまま1桁で表示されていたのを2桁で表示されるようにした。

### 変更前
<img width="496" alt="スクリーンショット 2023-05-21 1 48 09" src="https://github.com/tomonariha/working-day-deployer/assets/96340764/54e17065-52cd-41f3-9e53-d3ab07fca1e0">

### 変更後
<img width="501" alt="スクリーンショット 2023-05-21 1 40 36" src="https://github.com/tomonariha/working-day-deployer/assets/96340764/a0b4dbd9-c1a1-4844-9ae3-72858ff2482d">
